### PR TITLE
registration: workaround compiler peculiarity

### DIFF
--- a/lib/commanded/registration.ex
+++ b/lib/commanded/registration.ex
@@ -83,6 +83,22 @@ defmodule Commanded.Registration do
       @before_compile unquote(__MODULE__)
 
       alias unquote(__MODULE__)
+
+      # This is workaround for the issue described in
+      # https://github.com/commanded/commanded-swarm-registry/issues/2#issuecomment-1121685703
+      # In short, "handle_xxx" clauses defined in `__before_compile__/1` are not available in runtime
+      # unless these dummy clauses are present in `__using__/1`
+      @impl true
+      def handle_call(:will_not_be_called, _, _) do
+      end
+
+      @impl true
+      def handle_cast(:will_not_be_called, _) do
+      end
+
+      @impl true
+      def handle_info(:will_not_be_called, _) do
+      end
     end
   end
 

--- a/test/registration/handle_delegation_test.exs
+++ b/test/registration/handle_delegation_test.exs
@@ -1,0 +1,30 @@
+defmodule Commanded.Registration.HandleDelegationTest do
+  use ExUnit.Case
+
+  alias Commanded.Aggregates.Aggregate
+  alias Commanded.Registration.HandleFunctionDelegationApp
+
+  setup do
+    start_supervised!(HandleFunctionDelegationApp)
+
+    :ok
+  end
+
+  describe "delegate to clauses defined in registry" do
+    test "handle_call/3" do
+      assert :bar == Aggregate.handle_call(:foo, :whatever, state())
+    end
+
+    test "handle_cast/2" do
+      assert :baz == Aggregate.handle_cast(:bar, state())
+    end
+
+    test "handle_info/2" do
+      assert :yahoo == Aggregate.handle_info(:baz, state())
+    end
+
+    defp state do
+      %{application: HandleFunctionDelegationApp}
+    end
+  end
+end

--- a/test/registration/support/handle_function_delegation_app.ex
+++ b/test/registration/support/handle_function_delegation_app.ex
@@ -1,0 +1,14 @@
+defmodule Commanded.Registration.HandleFunctionDelegationApp do
+  alias Commanded.EventStore.Adapters.InMemory
+  alias Commanded.Registration.HandleFunctionDelegationRegistry
+  alias Commanded.Serialization.JsonSerializer
+
+  use Commanded.Application,
+    otp_app: :commanded,
+    event_store: [
+      adapter: InMemory,
+      serializer: JsonSerializer
+    ],
+    pubsub: :local,
+    registry: HandleFunctionDelegationRegistry
+end

--- a/test/registration/support/handle_function_delegation_registry.ex
+++ b/test/registration/support/handle_function_delegation_registry.ex
@@ -1,0 +1,51 @@
+defmodule Commanded.Registration.HandleFunctionDelegationRegistry do
+  require Logger
+
+  @behaviour Commanded.Registration.Adapter
+
+  @impl Commanded.Registration.Adapter
+  def child_spec(application, _config) do
+    registry_name = Module.concat([application, LocalRegistry])
+
+    child_spec = [
+      {Registry, keys: :unique, name: registry_name}
+    ]
+
+    {:ok, child_spec, %{registry_name: registry_name}}
+  end
+
+  @impl Commanded.Registration.Adapter
+  def supervisor_child_spec(_adapter_meta, _module, _arg) do
+  end
+
+  @impl Commanded.Registration.Adapter
+  def start_child(_adapter_meta, _name, _supervisor, _child_spec) do
+  end
+
+  @impl Commanded.Registration.Adapter
+  def start_link(_adapter_meta, _name, _module, _args, _start_opts) do
+  end
+
+  @impl Commanded.Registration.Adapter
+  def whereis_name(_adapter_meta, _name) do
+  end
+
+  @impl Commanded.Registration.Adapter
+  def via_tuple(_adapter_meta, _name) do
+  end
+
+  @doc false
+  def handle_call(:foo, _from, _state) do
+    :bar
+  end
+
+  @doc false
+  def handle_cast(:bar, _state) do
+    :baz
+  end
+
+  @doc false
+  def handle_info(:baz, _state) do
+    :yahoo
+  end
+end


### PR DESCRIPTION
This is workaround for the issue described in https://github.com/commanded/commanded-swarm-registry/issues/2#issuecomment-1121685703

Without this change :commanded-swarm-registry does not work properly.